### PR TITLE
T6002 - Não estou conseguindo filtrar prazo final para a próxima atividade

### DIFF
--- a/mail_activity_done/models/mail_activity.py
+++ b/mail_activity_done/models/mail_activity.py
@@ -42,3 +42,9 @@ class MailActivityMixin(models.AbstractModel):
             [list]: Ids das Atividades por State
         """
         return self.activity_ids.filtered(lambda x: x.done == False).mapped('state')
+
+    def _search_activity_date_deadline(self, operator, operand, done_only=True):
+        res = super(MailActivityMixin, self)._search_activity_date_deadline(operator, operand)
+        if done_only:
+            res.append(('activity_ids.done', '=', False))
+        return res


### PR DESCRIPTION
# Descrição

- [FIX] Corrige bug de filtrar por atividades vencidas ou vencendo
  - Adiciona comportamento em função search do campo computado 'activity_date_deadline' para filtrar apenas as atividades que não estão concluídas.

# Informações adicionais

- [T6002](https://multi.multidados.tech/web?#id=6411&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)