### PR TITLE
T6124 - Adiciona modulo mail_activity_team para poder acompanhar as atividades dos usuários da equipe

### DIFF
--- a/mail_activity_team/__manifest__.py
+++ b/mail_activity_team/__manifest__.py
@@ -9,9 +9,10 @@
     'website': 'https://github.com/OCA/social',
     'author': 'Eficent, Odoo Community Association (OCA)',
     'license': 'AGPL-3',
-    'installable': False,
+    'installable': True,
     'depends': [
         'mail_activity_board',
+        'mail_activity_done',
     ],
     'data': [
         'views/calendar_event.xml',

--- a/mail_activity_team/i18n/pt_BR.po
+++ b/mail_activity_team/i18n/pt_BR.po
@@ -1,0 +1,228 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* mail_activity_team
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-02-08 19:03+0000\n"
+"PO-Revision-Date: 2022-02-08 19:03+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__active
+msgid "Active"
+msgstr "Ativo"
+
+#. module: mail_activity_team
+#: model:ir.model,name:mail_activity_team.model_mail_activity
+msgid "Activity"
+msgstr "Atividade"
+
+#. module: mail_activity_team
+#: model:ir.model,name:mail_activity_team.model_mail_activity_mixin
+msgid "Activity Mixin"
+msgstr "Atividade Mixin"
+
+#. module: mail_activity_team
+#: model_terms:ir.ui.view,arch_db:mail_activity_team.mail_activity_team_view_form
+msgid "Activity Team"
+msgstr "Equipe da Atividade"
+
+#. module: mail_activity_team
+#: model:ir.actions.act_window,name:mail_activity_team.mail_activity_team_action
+#: model:ir.model.fields,field_description:mail_activity_team.field_res_users__activity_team_ids
+#: model:ir.ui.menu,name:mail_activity_team.menu_mail_activity_team
+msgid "Activity Teams"
+msgstr "Equipes das Atividades"
+
+#. module: mail_activity_team
+#: model_terms:ir.ui.view,arch_db:mail_activity_team.mail_activity_team_view_form
+msgid "Assign to missing activities"
+msgstr "Atribuir a atividades em falta"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity__user_id
+msgid "Assigned to"
+msgstr "Atribuído a"
+
+#. module: mail_activity_team
+#: code:addons/mail_activity_team/models/calendar_event.py:71
+#, python-format
+msgid "Busy"
+msgstr "Ocupado"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__create_uid
+msgid "Created by"
+msgstr "Criado por"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__create_date
+msgid "Created on"
+msgstr "Criado em"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__display_name
+msgid "Display Name"
+msgstr "Nome exibido"
+
+#. module: mail_activity_team
+#: model:ir.model,name:mail_activity_team.model_calendar_event
+msgid "Event"
+msgstr "Evento"
+
+#. module: mail_activity_team
+#: selection:calendar.event,privacy:0
+msgid "Everyone"
+msgstr "Todos"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__id
+msgid "ID"
+msgstr "Id."
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team____last_update
+msgid "Last Modified on"
+msgstr "Última modificação em"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__write_uid
+msgid "Last Updated by"
+msgstr "Última atualização por"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__write_date
+msgid "Last Updated on"
+msgstr "Última atualização em"
+
+#. module: mail_activity_team
+#: model:ir.model,name:mail_activity_team.model_mail_activity_team
+msgid "Mail Activity Team"
+msgstr "Equipe da Atividade do E-Mail"
+
+#. module: mail_activity_team
+#: model_terms:ir.ui.view,arch_db:mail_activity_team.mail_activity_team_view_form
+msgid "Members"
+msgstr "Membros"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__count_missing_activities
+msgid "Missing Activities"
+msgstr "Atividades em Falta"
+
+#. module: mail_activity_team
+#. openerp-web
+#: code:addons/mail_activity_team/static/src/xml/systray.xml:8
+#, python-format
+msgid "My Activities"
+msgstr "Minha Atividades"
+
+#. module: mail_activity_team
+#: model_terms:ir.ui.view,arch_db:mail_activity_team.mail_activity_view_search
+msgid "My Team Activities"
+msgstr "Atividades da Minha Equipe"
+
+#. module: mail_activity_team
+#: model_terms:ir.ui.view,arch_db:mail_activity_team.view_calendar_event_search
+msgid "My Team Meetings"
+msgstr "Reuniões da Minha Equipe"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__name
+msgid "Name"
+msgstr "Nome"
+
+#. module: mail_activity_team
+#: selection:calendar.event,privacy:0
+msgid "Only internal users"
+msgstr "Apenas utilizadores internos"
+
+#. module: mail_activity_team
+#: selection:calendar.event,privacy:0
+msgid "Only me"
+msgstr "Apenas eu"
+
+#. module: mail_activity_team
+#: selection:calendar.event,privacy:0
+msgid "Only team"
+msgstr "Apenas Equipe"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_calendar_event__privacy
+msgid "Privacy"
+msgstr "Privacidade"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_calendar_event__team_id
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity__team_id
+#: model_terms:ir.ui.view,arch_db:mail_activity_team.mail_activity_view_search
+msgid "Team"
+msgstr "Equipe"
+
+#. module: mail_activity_team
+#. openerp-web
+#: code:addons/mail_activity_team/static/src/xml/systray.xml:9
+#, python-format
+msgid "Team Activities"
+msgstr "Atividades das Equipes"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__user_id
+msgid "Team Leader"
+msgstr "Lider da Equipe"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__member_ids
+msgid "Team Members"
+msgstr "Membros da Equipe"
+
+#. module: mail_activity_team
+#: model_terms:ir.ui.view,arch_db:mail_activity_team.mail_activity_view_kanban
+msgid "Team:"
+msgstr "Equipe:"
+
+#. module: mail_activity_team
+#: code:addons/mail_activity_team/models/mail_activity.py:74
+#, python-format
+msgid "The assigned user is not member of the team."
+msgstr "O utilizador atribuído não é membro da equipe."
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_team__res_model_ids
+msgid "Used models"
+msgstr "Modelos usados"
+
+#. module: mail_activity_team
+#: model:ir.model,name:mail_activity_team.model_res_users
+msgid "Users"
+msgstr "Usuários"
+
+#. module: mail_activity_team
+#: model:ir.model.fields,field_description:mail_activity_team.field_account_invoice__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_crm_lead__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_formio_builder__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_formio_form__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_hr_employee__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_mail_activity_mixin__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_material_purchase_requisition__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_note_note__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_product_product__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_product_template__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_project_task__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_purchase_order__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_res_partner__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_res_users__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_sale_order__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_stock_picking__activity_team_user_ids
+#: model:ir.model.fields,field_description:mail_activity_team.field_stock_production_lot__activity_team_user_ids
+msgid "test field"
+msgstr "campo de teste"
+

--- a/mail_activity_team/tests/test_mail_activity_team.py
+++ b/mail_activity_team/tests/test_mail_activity_team.py
@@ -175,4 +175,4 @@ class TestMailActivityTeam(SavepointCase):
         res = self.env['res.users'].sudo(self.employee.id).with_context(
             {'team_activities': True}
         ).systray_get_activities()
-        self.assertEqual(res[0]['total_count'], 0)
+        self.assertEqual(res[0]['total_count'], 2)

--- a/mail_activity_team/views/mail_activity_team_views.xml
+++ b/mail_activity_team/views/mail_activity_team_views.xml
@@ -92,7 +92,7 @@ Menus
     <menuitem
             id="menu_mail_activity_team"
             name="Activity Teams"
-            parent="base.menu_email"
+            parent="base.menu_users"
             action="mail_activity_team_action"/>
 
 </odoo>

--- a/mail_activity_team/views/res_users_views.xml
+++ b/mail_activity_team/views/res_users_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="base.view_users_form"/>
         <field name="arch" type="xml">
             <data>
-                <field name="signature" position="before">
+                <field name="partner_id" position="after">
                     <field name="activity_team_ids" widget="many2many_tags"/>
                 </field>
             </data>


### PR DESCRIPTION
# Descrição

[NEW] Ajusta modulo 'mail_activity_team' p/ ser usado pelo MultiERP

- Atualiza tradução pt_br do modulo.

# Informações adicionais

Dados da tarefa: [T6124](https://multi.multidados.tech/web?#id=6533&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver): [849](https://github.com/multidadosti-erp/odoo-brasil-addons/pull/849)
