### PR TITLE
T6185 - Atrasos nos cards não estão atualizando

### DIFF
--- a/mail_activity_done/models/mail_activity.py
+++ b/mail_activity_done/models/mail_activity.py
@@ -42,3 +42,18 @@ class MailActivityMixin(models.AbstractModel):
             [list]: Ids das Atividades por State
         """
         return self.activity_ids.filtered(lambda x: x.done == False).mapped('state')
+
+    def _search_activity_date_deadline(self, operator, operand):
+        """ Atualiza método search, para considerar apenas atividades que
+        ainda não foram concluídas.
+
+        Args:
+            operator (str): tipo de operador comparativo
+            operand (any): qualquer valor que está sendo comparado
+
+        Returns:
+            list: domain do search
+        """
+        res = super(MailActivityMixin, self)._search_activity_date_deadline(operator, operand)
+        res.append(('activity_ids.done', '=', False))
+        return res


### PR DESCRIPTION
# Descrição

- [FIX] Ajusta search do campo da model 'mail.activity.mixin'
  - Um search personalizado é utilizado para retornar as atividades que estão atrasadas, mas esse search não estava considerando apenas as atividades que não estão concluídas.

# Informações adicionais

- [T6185](https://multi.multidados.tech/web#id=6594&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)