### PR TITLE
T6229 - Corrigir progressbar das atividades que aparecem como atrasadas

### DIFF
--- a/mail_activity_done/models/mail_activity.py
+++ b/mail_activity_done/models/mail_activity.py
@@ -45,6 +45,19 @@ class MailActivityMixin(models.AbstractModel):
                 lambda x: not x.done and x.status == 'active'
             ).mapped('state')
 
+    def _get_activity_where_statement(self):
+        """ Adiciona condição em cláusula where de sql utilizado em
+        função do core para obter atividades atrasadas. Adiciona as
+        condições para pegar apenas atividades que não foram concluídas
+        (done = False) e atividades que estão ativas (status = 'active').
+
+        Returns:
+            str: Condições do WHERE executado na tabela 'mail.activity'
+        """
+        res = super(MailActivityMixin, self)._get_activity_where_statement()
+        res += "AND done = False AND status = 'active' "
+        return res
+
     def _search_activity_date_deadline(self, operator, operand):
         """ Atualiza método search, para considerar apenas atividades que
         ainda não foram concluídas.

--- a/mail_activity_done/models/mail_activity.py
+++ b/mail_activity_done/models/mail_activity.py
@@ -41,7 +41,9 @@ class MailActivityMixin(models.AbstractModel):
         Returns:
             [list]: Ids das Atividades por State
         """
-        return self.activity_ids.filtered(lambda x: x.done == False).mapped('state')
+        return self.activity_ids.filtered(
+                lambda x: not x.done and x.status == 'active'
+            ).mapped('state')
 
     def _search_activity_date_deadline(self, operator, operand):
         """ Atualiza método search, para considerar apenas atividades que


### PR DESCRIPTION
# Descrição

- [FIX] Mesclando parte do método removido do 'schedule_activity_app'
  - Inclui comportamento esperado em função que havia sido implementada no 'schedule_activity_app', mas que deveria ficar no módulo 'mail_activity_done'.
- [FIX] Adiciona verificação de atividades ativas e não concluídas
  - Adiciona comportamento na função de obter as cláusulas where na busca de atividades vencidas para buscar apenas por atividades não concluídas e status = 'active'.

# Informações adicionais

- [T6229](https://multi.multidados.tech/web#id=6638&action=1139&active_id=12&model=project.task&view_type=form&menu_id=223)

PRs relacionados:
- [core](https://github.com/multidadosti-erp/odoo/pull/156)
- [private-addons](https://github.com/multidadosti-erp/multidadosti-private-addons/pull/717)