### PR TITLE
T6302 - Erro: Nas Atividades Atrasadas Mostra um Número e Qtde clica mostra outros registros

### DIFF
--- a/mail_activity_done/i18n/pt_BR.po
+++ b/mail_activity_done/i18n/pt_BR.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-12-03 12:48+0000\n"
-"PO-Revision-Date: 2021-12-03 12:48+0000\n"
+"POT-Creation-Date: 2022-04-13 19:23+0000\n"
+"PO-Revision-Date: 2022-04-13 19:23+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -23,30 +23,17 @@ msgid "%d days overdue"
 msgstr "%d dias de atraso"
 
 #. module: mail_activity_done
-#: code:addons/mail_activity_done/models/mail_activity.py:18
+#: code:addons/mail_activity_done/models/mail_activity.py:29
 #: model:ir.model.fields,field_description:mail_activity_done.field_mail_activity__active
 #, python-format
 msgid "Active"
 msgstr "Ativo"
 
 #. module: mail_activity_done
-#: model:ir.model.fields,field_description:mail_activity_done.field_account_invoice__activity_ids
-#: model:ir.model.fields,field_description:mail_activity_done.field_crm_lead__activity_ids
-#: model:ir.model.fields,field_description:mail_activity_done.field_formio_builder__activity_ids
-#: model:ir.model.fields,field_description:mail_activity_done.field_formio_form__activity_ids
 #: model:ir.model.fields,field_description:mail_activity_done.field_hr_employee__activity_ids
 #: model:ir.model.fields,field_description:mail_activity_done.field_mail_activity_mixin__activity_ids
-#: model:ir.model.fields,field_description:mail_activity_done.field_material_purchase_requisition__activity_ids
-#: model:ir.model.fields,field_description:mail_activity_done.field_note_note__activity_ids
-#: model:ir.model.fields,field_description:mail_activity_done.field_product_product__activity_ids
-#: model:ir.model.fields,field_description:mail_activity_done.field_product_template__activity_ids
-#: model:ir.model.fields,field_description:mail_activity_done.field_project_task__activity_ids
-#: model:ir.model.fields,field_description:mail_activity_done.field_purchase_order__activity_ids
 #: model:ir.model.fields,field_description:mail_activity_done.field_res_partner__activity_ids
 #: model:ir.model.fields,field_description:mail_activity_done.field_res_users__activity_ids
-#: model:ir.model.fields,field_description:mail_activity_done.field_sale_order__activity_ids
-#: model:ir.model.fields,field_description:mail_activity_done.field_stock_picking__activity_ids
-#: model:ir.model.fields,field_description:mail_activity_done.field_stock_production_lot__activity_ids
 msgid "Activities"
 msgstr "Atividades"
 
@@ -61,19 +48,19 @@ msgid "Activity Mixin"
 msgstr "Atividade Mixin"
 
 #. module: mail_activity_done
+#: model:ir.model,name:mail_activity_done.model_mail_activity_type
+msgid "Activity Type"
+msgstr "Tipo de Atividade"
+
+#. module: mail_activity_done
 #: selection:mail.activity,status:0
 msgid "Ativo"
 msgstr ""
 
 #. module: mail_activity_done
 #: selection:mail.activity,status:0
-msgid "Attended"
-msgstr "Compareceu"
-
-#. module: mail_activity_done
-#: selection:mail.activity,status:0
 msgid "Canceled"
-msgstr "Cancelado"
+msgstr "Cancelada"
 
 #. module: mail_activity_done
 #: selection:mail.activity,status:0
@@ -125,9 +112,10 @@ msgid "Planned"
 msgstr "Planejada"
 
 #. module: mail_activity_done
-#: selection:mail.activity,status:0
-msgid "Started Appointment"
-msgstr "Iniciou Consulta"
+#: model:ir.model.fields,field_description:mail_activity_done.field_mail_activity__type_id_show_on_plan_activities
+#: model:ir.model.fields,field_description:mail_activity_done.field_mail_activity_type__show_on_plan_activities
+msgid "Show on Plan Activities"
+msgstr "Mostrar em Planejados"
 
 #. module: mail_activity_done
 #: model:ir.model.fields,field_description:mail_activity_done.field_mail_activity__state
@@ -165,4 +153,3 @@ msgstr "Usuários"
 #, python-format
 msgid "Yesterday"
 msgstr "Ontem"
-

--- a/mail_activity_done/i18n/pt_BR.po
+++ b/mail_activity_done/i18n/pt_BR.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-13 19:23+0000\n"
-"PO-Revision-Date: 2022-04-13 19:23+0000\n"
+"POT-Creation-Date: 2022-04-13 20:33+0000\n"
+"PO-Revision-Date: 2022-04-13 20:33+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -115,7 +115,7 @@ msgstr "Planejada"
 #: model:ir.model.fields,field_description:mail_activity_done.field_mail_activity__type_id_show_on_plan_activities
 #: model:ir.model.fields,field_description:mail_activity_done.field_mail_activity_type__show_on_plan_activities
 msgid "Show on Plan Activities"
-msgstr "Mostrar em Planejados"
+msgstr "Mostrar Planejados"
 
 #. module: mail_activity_done
 #: model:ir.model.fields,field_description:mail_activity_done.field_mail_activity__state

--- a/mail_activity_done/models/__init__.py
+++ b/mail_activity_done/models/__init__.py
@@ -1,2 +1,3 @@
 from . import mail_activity
 from . import res_users
+from . import mail_activity_type

--- a/mail_activity_done/models/mail_activity.py
+++ b/mail_activity_done/models/mail_activity.py
@@ -29,10 +29,10 @@ class MailActivityMixin(models.AbstractModel):
 
     _inherit = 'mail.activity.mixin'
 
-    activity_ids = fields.One2many(
-        domain=lambda self: [('res_model', '=', self._name),
-                             ('active', '=', True)])
-
+    # comentado para não conflitar com o modulo: schedule_activity_app
+    # activity_ids = fields.One2many(
+    #     domain=lambda self: [('res_model', '=', self._name),
+    #                          ('active', '=', True)])
 
     def get_activities_states(self):
         """Sobrescreve método do Core para adicionar
@@ -58,17 +58,18 @@ class MailActivityMixin(models.AbstractModel):
         res += "AND done = False AND status = 'active' "
         return res
 
-    def _search_activity_date_deadline(self, operator, operand):
-        """ Atualiza método search, para considerar apenas atividades que
-        ainda não foram concluídas.
+    # comentado para não conflitar com o modulo: schedule_activity_app
+    # def _search_activity_date_deadline(self, operator, operand):
+    #     """ Atualiza método search, para considerar apenas atividades que
+    #     ainda não foram concluídas.
 
-        Args:
-            operator (str): tipo de operador comparativo
-            operand (any): qualquer valor que está sendo comparado
+    #     Args:
+    #         operator (str): tipo de operador comparativo
+    #         operand (any): qualquer valor que está sendo comparado
 
-        Returns:
-            list: domain do search
-        """
-        res = super(MailActivityMixin, self)._search_activity_date_deadline(operator, operand)
-        res.append(('activity_ids.done', '=', False))
-        return res
+    #     Returns:
+    #         list: domain do search
+    #     """
+    #     res = super(MailActivityMixin, self)._search_activity_date_deadline(operator, operand)
+    #     res.append(('activity_ids.done', '=', False))
+    #     return res

--- a/mail_activity_done/models/mail_activity.py
+++ b/mail_activity_done/models/mail_activity.py
@@ -7,16 +7,30 @@ class MailActivity(models.Model):
 
     _inherit = 'mail.activity'
 
-    active = fields.Boolean(default=True)
-    done = fields.Boolean(default=False)
-    state = fields.Selection(selection_add=[
-        ('done', 'Done')], compute='_compute_state')
+    active = fields.Boolean(
+        default=True)
+
+    done = fields.Boolean(
+        default=False)
+
+    state = fields.Selection(
+        selection_add=[
+            ('done', 'Done')
+        ],
+        compute='_compute_state')
+
     date_done = fields.Date(
-        'Completed Date', index=True, readonly=True,
+        'Completed Date',
+        index=True,
+        readonly=True,
     )
+
     status = fields.Selection(
         selection=[('active', _('Active')),],
         default='active')
+
+    type_id_show_on_plan_activities = fields.Boolean(
+        related='activity_type_id.show_on_plan_activities')
 
     @api.depends('date_deadline', 'done')
     def _compute_state(self):
@@ -29,10 +43,14 @@ class MailActivityMixin(models.AbstractModel):
 
     _inherit = 'mail.activity.mixin'
 
-    # comentado para não conflitar com o modulo: schedule_activity_app
-    # activity_ids = fields.One2many(
-    #     domain=lambda self: [('res_model', '=', self._name),
-    #                          ('active', '=', True)])
+    activity_ids = fields.One2many(
+        domain=lambda self: [
+            ('res_model', '=', self._name),
+            ('active', '=', True),
+            ('done', '=', False),
+            ('type_id_show_on_plan_activities', '=', True)
+        ]
+    )
 
     def get_activities_states(self):
         """Sobrescreve método do Core para adicionar
@@ -58,18 +76,17 @@ class MailActivityMixin(models.AbstractModel):
         res += "AND done = False AND status = 'active' "
         return res
 
-    # comentado para não conflitar com o modulo: schedule_activity_app
-    # def _search_activity_date_deadline(self, operator, operand):
-    #     """ Atualiza método search, para considerar apenas atividades que
-    #     ainda não foram concluídas.
+    def _search_activity_date_deadline(self, operator, operand):
+        """ Atualiza método search, para considerar apenas atividades que
+        ainda não foram concluídas.
 
-    #     Args:
-    #         operator (str): tipo de operador comparativo
-    #         operand (any): qualquer valor que está sendo comparado
+        Args:
+            operator (str): tipo de operador comparativo
+            operand (any): qualquer valor que está sendo comparado
 
-    #     Returns:
-    #         list: domain do search
-    #     """
-    #     res = super(MailActivityMixin, self)._search_activity_date_deadline(operator, operand)
-    #     res.append(('activity_ids.done', '=', False))
-    #     return res
+        Returns:
+            list: domain do search
+        """
+        res = super(MailActivityMixin, self)._search_activity_date_deadline(operator, operand)
+        res.append(('activity_ids.done', '=', False))
+        return res

--- a/mail_activity_done/models/mail_activity_type.py
+++ b/mail_activity_done/models/mail_activity_type.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class MailActivityType(models.Model):
+    _inherit = 'mail.activity.type'
+
+    show_on_plan_activities = fields.Boolean(
+        string='Show on Plan Activities',
+        default=True
+    )

--- a/mail_activity_done/models/res_users.py
+++ b/mail_activity_done/models/res_users.py
@@ -12,20 +12,21 @@ class ResUsers(models.Model):
         # we should perhaps ask Odoo to add a hook here.
         query = """SELECT m.id, count(*), act.res_model as model,
                         CASE
-                            WHEN %(today)s::date -
-                            act.date_deadline::date = 0 Then 'today'
-                            WHEN %(today)s::date -
-                            act.date_deadline::date > 0 Then 'overdue'
-                            WHEN %(today)s::date -
-                            act.date_deadline::date < 0 Then 'planned'
+                            WHEN %(today)s::date - act.date_deadline::date = 0 Then 'today'
+                            WHEN %(today)s::date - act.date_deadline::date > 0 Then 'overdue'
+                            WHEN %(today)s::date - act.date_deadline::date < 0 Then 'planned'
                         END AS states
                     FROM mail_activity AS act
-                    JOIN ir_model AS m ON act.res_model_id = m.id
+                        JOIN ir_model AS m ON act.res_model_id = m.id
+                        JOIN mail_activity_type mat on act.activity_type_id = mat.id
+
                     WHERE act.user_id = %(user_id)s
                       AND act.done = False
                       AND act.status = 'active'
+                      AND mat.show_on_plan_activities = True
+
                     GROUP BY m.id, states, act.res_model;
-                    """
+                """
         self.env.cr.execute(query, {
             'today': fields.Date.context_today(self),
             'user_id': self.env.uid,

--- a/mail_activity_done/views/mail_activity_views.xml
+++ b/mail_activity_done/views/mail_activity_views.xml
@@ -74,6 +74,7 @@
             <field name="date_deadline" position="after">
                 <field name="state"/>
                 <field name="date_done"/>
+                <field name="type_id_show_on_plan_activities"/>
             </field>
             <tree position="attributes">
                 <attribute name="decoration-muted">state == 'done'</attribute>


### PR DESCRIPTION
# Descrição

[FIX] Remove campo 'activity_ids' que estava conflitando com o modulo 'schedule_activity_app'
 
[FIX] Corrige Filtro e systray das atividades modulo 'mail_activity_done'

- Adiciona campo: type_id_show_on_plan_activities
- Adiciona campo: activity_ids
- Atualiza SQL para Filtros das Atividades
- Atualiza tradução pt_br

[FIX] Ajusta 'systray_get_activities' modulo 'mail_activity_team'
- Ajusta metodo 'mail_activity_team' referente ao SQL para filtrar
  corretamente as atividades no systray do odoo.

# Informações adicionais

Dados da tarefa: [T6302](https://multi.multidados.tech/web?#id=6711&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

PR(s) relacionado(s) (se houver): [728](https://github.com/multidadosti-erp/multidadosti-private-addons/pull/728)
