### PR TITLE
T8472 - Verificar atividades atrasadas que não estão ficando com a cor vermelha

### DIFF
--- a/mail_activity_done/models/mail_activity.py
+++ b/mail_activity_done/models/mail_activity.py
@@ -19,7 +19,7 @@ class MailActivity(models.Model):
         selection_add=[
             ('done', 'Done')
         ],
-        store=True,
+        store=False,
         compute='_compute_state'
     )
 


### PR DESCRIPTION
# Descrição

- Remove com store=True do campo 'state' da Atividade
  - O campo deve ser dinâmico para ser calculado a cada dia.

# Informações adicionais

- [T8472](https://multi.multidados.tech/web?#id=8881&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)