### PR TITLE
T8912 - Retirar acesso a Todas as Atividades

### DIFF
--- a/mail_activity_board/static/src/xml/systray.xml
+++ b/mail_activity_board/static/src/xml/systray.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
 
-    <t t-extend="mail.systray.ActivityMenu">
+    <!-- opcao de visualizar todas as atividades nao obedece permissao
+    exibindo todos as atividades mesmo quando o usuario tem permissao
+    de ver somente as suas permissoes -->
+
+    <!-- <t t-extend="mail.systray.ActivityMenu">
         <t t-jquery=".o_mail_systray_dropdown_items" t-operation="before">
             <div class="o_mail_systray_dropdown_top">
                 <button type="button" class="btn btn-link o_all_activities_button">Open All</button>
             </div>
         </t>
-    </t>
+    </t> -->
 
 </templates>


### PR DESCRIPTION
# Descrição

* Desabilita menu systray de visualizar todas as atividades

Link do todas as atividades exibia todas as atividades mesmo quando o usuario tinha permissao de ver apenas suas atividades

# Informações adicionais

Dados da tarefa: [T8912](https://multi.multidados.tech/web#id=9321&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)

