### PR TITLE
T9007 - Permissão de Funções de Atividades" dando erro ao criar atividades com nível menor que gestor

### DIFF
--- a/mail_activity_team/__manifest__.py
+++ b/mail_activity_team/__manifest__.py
@@ -20,7 +20,7 @@
         'security/ir.model.access.csv',
         'security/mail_activity_team_security.xml',
         'views/mail_activity_team_views.xml',
-        'views/mail_activity_views.xml',
+        # 'views/mail_activity_views.xml',
         'views/res_users_views.xml',
     ],
     'demo': [

--- a/mail_activity_team/models/mail_activity_team.py
+++ b/mail_activity_team/models/mail_activity_team.py
@@ -55,6 +55,7 @@ class MailActivityTeam(models.Model):
 
     @api.onchange('member_ids')
     def _onchange_member_ids(self):
+        self.env['ir.rule'].clear_caches()
         if self.user_id and self.user_id not in self.member_ids:
             self.user_id = False
 

--- a/mail_activity_team/security/mail_activity_team_security.xml
+++ b/mail_activity_team/security/mail_activity_team_security.xml
@@ -1,10 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="0">
+    <function name="write" model="ir.model.data">
+        <function name="search" model="ir.model.data">
+            <value eval="[('model', 'in', ['ir.rule']),
+                          ('name', '=', 'mail_activity_rule_my_team')]"/>
+        </function>
+        <value eval="{'noupdate': False}"/>
+    </function>
 
     <record id="mail_activity_rule_my_team" model="ir.rule">
         <field name="name">mail.activity: user: my team</field>
         <field name="model_id" ref="mail.model_mail_activity"/>
-        <field name="domain_force">["|", ('team_id', 'in', user.activity_team_ids.ids), ('user_id', 'in', user.activity_team_ids.member_ids.ids)]</field>
+        <field name="domain_force">["|", "|", "|",
+                                    ('team_id', 'in', user.activity_team_ids.ids),
+                                    ('user_id', 'in', user.activity_team_ids.mapped('member_ids').ids),
+                                    ('user_id', '=', user.id),
+                                    ('create_user_id', '=', user.id)]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
         <field name="perm_create" eval="True"/>
         <field name="perm_read" eval="True"/>

--- a/mail_activity_team/views/mail_activity_views.xml
+++ b/mail_activity_team/views/mail_activity_views.xml
@@ -23,7 +23,7 @@
         </field>
     </record-->
 
-     <record id="mail_activity_view_kanban" model="ir.ui.view">
+     <!-- <record id="mail_activity_view_kanban" model="ir.ui.view">
          <field name="name">mail.activity.boards.view.kanban</field>
          <field name="model">mail.activity</field>
          <field name="inherit_id" ref="mail_activity_board.mail_activity_view_kanban"/>
@@ -37,25 +37,25 @@
                  </div>
              </xpath>
          </field>
-    </record>
+    </record> -->
 
         <!-- SEARCH VIEW -->
+    <!-- Desabilitar por enquanto
     <record id="mail_activity_view_search" model="ir.ui.view">
         <field name="name">mail.activity.boards.view.search</field>
         <field name="model">mail.activity</field>
         <field name="inherit_id" ref="mail_activity_board.mail_activity_view_search"/>
         <field name="priority" eval="2"/>
         <field name="arch" type="xml">
-            <!-- Desabilitar por enquanto
             <xpath expr='//field[@name="user_id"]' position='before'>
                 <field name="team_id"/>
             </xpath>
             <xpath expr='//filter[@name="activities_my"]' position='after'>
                 <filter name="my_team_activities" string="My Team Activities" domain="[('team_id.member_ids', '=', uid)]"/>
-            </xpath -->
+            </xpath>
             <group position='inside'>
                 <filter name='team' string="Team" context="{'group_by': 'team_id'}"/>
             </group>
         </field>
-    </record>
+    </record-->
 </odoo>


### PR DESCRIPTION
# Descrição

- Regra de acesso de Supervisores à atividades com erro
    - O domínio da regra de usuários de atividades não estava sendo aplicada para a regra de Supervisores.
    - Força noupdate=False na regra de Supervisores de Atividades.

- Comentários em código ref a Equipes de Atividades
    - Mantém código ref. a equipes de atividades comentados para implementação posterior na atribuição de atividades por equipes.

# Informações adicionais

- [T9007](https://multi.multidados.tech/web#id=9416&action=1109&active_id=10626&model=project.task&view_type=form&menu_id=465)